### PR TITLE
 include UserStrings.json with the build, rather than VS Code tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -35,23 +35,6 @@
 			}
 		},
 		{
-			"label": "copy config",
-			"command": "pwsh",
-			"args": [
-				"-c",
-				"Copy-Item ${workspaceFolder}/AzFunction/config/UserStrings.json ${workspaceFolder}/AzFunction/bin/Debug/netcoreapp3.1/SweepBroom/"
-			],
-			"type": "process",
-			"dependsOn": "build",
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-			"options": {
-				"cwd": "${workspaceFolder}/AzFunction"
-			}
-		},
-		{
 			"label": "clean release",
 			"command": "dotnet",
 			"args": [
@@ -78,32 +61,15 @@
 				"/consoleloggerparameters:NoSummary"
 			],
 			"type": "process",
-			"dependsOn": "copy config release",
+			"dependsOn": "clean release",
 			"problemMatcher": "$msCompile",
 			"options": {
 				"cwd": "${workspaceFolder}/AzFunction"
 			}
 		},
 		{
-			"label": "copy config release",
-			"command": "pwsh",
-			"args": [
-				"-c",
-				"Copy-Item ${workspaceFolder}/AzFunction/config/UserStrings.json ${workspaceFolder}/AzFunction/bin/Release/netcoreapp3.1/SweepBroom/"
-			],
-			"type": "process",
-			"dependsOn": "publish",
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-			"options": {
-				"cwd": "${workspaceFolder}/AzFunction"
-			}
-		},
-		{
 			"type": "func",
-			"dependsOn": "copy config",
+			"dependsOn": "build",
 			"options": {
 				"cwd": "${workspaceFolder}/AzFunction/bin/Debug/netcoreapp3.1"
 			},

--- a/AzFunction/AzFunction.csproj
+++ b/AzFunction/AzFunction.csproj
@@ -15,5 +15,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
+    <None Update="config/UserStrings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/AzFunction/AzFunction.csproj
+++ b/AzFunction/AzFunction.csproj
@@ -17,7 +17,7 @@
     </None>
     <None Update="config/UserStrings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
   </ItemGroup>
 </Project>

--- a/AzFunction/SweepBroom.cs
+++ b/AzFunction/SweepBroom.cs
@@ -30,7 +30,7 @@ namespace BroomBot
             string project = Environment.GetEnvironmentVariable("Project", EnvironmentVariableTarget.Process);
 
             // Set up the user strings
-            string configPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), @"..\SweepBroom\UserStrings.json");
+            string configPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), @"..\config\UserStrings.json");
             BroomBotStrings userStrings = new BroomBotStrings(configPath);
             int staleAge = Convert.ToInt32(userStrings.StaleAge);
             int warningCount = Convert.ToInt32(userStrings.WarningCount);


### PR DESCRIPTION
BroomBot depends on a series of user configurable strings that are used as messages and variables during execution. This PR changes the `.csproj` to include that file in the build and publish, rather than to depend on VS Code tasks which are only helpful when debugging locally.