### PR TITLE
Separate comment message for when abandoning PR vs just warning

### DIFF
--- a/BroomBot/BroomBotStrings.cs
+++ b/BroomBot/BroomBotStrings.cs
@@ -9,6 +9,7 @@ namespace BroomBot
     public class BroomBotStrings
     {
         public string PullRequestIsStale { get; set; }
+        public string PullRequestIsAbandoned { get; set; }
         public string BroomBotName { get; set; }
         public string WarningPrefix { get; set; }
         public string StaleAge { get; set; }

--- a/BroomBot/BroomBotUtils.cs
+++ b/BroomBot/BroomBotUtils.cs
@@ -105,7 +105,7 @@ namespace BroomBot
                 }
 
                 // Add a comment to the PR describing that it's stale
-                Comment comment = new Comment { Content = string.Format(warningMessage, pr.Key.CreatedBy.Id) };
+                Comment comment = new Comment { Content = string.Format(commentMessage, pr.Key.CreatedBy.Id) };
                 List<Comment> commentList = new List<Comment> { comment };
                 GitPullRequestCommentThread commentThread = new GitPullRequestCommentThread
                 {

--- a/BroomBot/SweepBroom.cs
+++ b/BroomBot/SweepBroom.cs
@@ -78,7 +78,14 @@ namespace BroomBot
                 }
 
                 // tag & update stale PRs and return candidates for abandonment
-                IList<GitPullRequest> abandonmentCandidates = await BroomBotUtils.TagStalePullRequests(gitClient, project, stalePRs, userStrings.WarningPrefix, warningCount, userStrings.PullRequestIsStale);
+                IList<GitPullRequest> abandonmentCandidates = await BroomBotUtils.TagStalePullRequests(
+                    gitClient,
+                    project,
+                    stalePRs,
+                    userStrings.WarningPrefix,
+                    warningCount,
+                    userStrings.PullRequestIsStale,
+                    userStrings.PullRequestIsAbandoned);
                 log.LogInformation($"Found {abandonmentCandidates.Count} pull requests that are due to be abandoned");
 
                 // PRs that need to be abandoned

--- a/config/BroomBot-ARMDeploy-Params.json
+++ b/config/BroomBot-ARMDeploy-Params.json
@@ -6,13 +6,13 @@
             "metadata": {
                 "description": "The name of the function app for BroomBot"
             },
-            "value": "broombotapp54"
+            "value": "broombotapp55"
         },
         "storageAccName": {
             "metadata": {
                 "description": "The name of the storage account for BroomBot"
             },
-            "value": "broombotstorage54"
+            "value": "broombotstorage55"
         },
         "storageAccountType": {
             "metadata": {

--- a/config/BroomBot-ARMDeploy-Params.json
+++ b/config/BroomBot-ARMDeploy-Params.json
@@ -6,13 +6,13 @@
             "metadata": {
                 "description": "The name of the function app for BroomBot"
             },
-            "value": "broombotapp"
+            "value": "broombotapp54"
         },
         "storageAccName": {
             "metadata": {
                 "description": "The name of the storage account for BroomBot"
             },
-            "value": "broombotstorage"
+            "value": "broombotstorage54"
         },
         "storageAccountType": {
             "metadata": {
@@ -36,19 +36,19 @@
             "metadata": {
                 "description": "Provide the Azure DevOps organization name"
             },
-            "value": "your-organization"
+            "value": "thomasrayner"
         },
         "project": {
             "metadata": {
                 "description": "Provide the Azure DevOps project name"
             },
-            "value": "your-project"
+            "value": "BroomBot"
         },
         "SweepInterval": {
             "metadata": {
                 "description": "NCRONTAB expression for how often sweeps will take place (more info: https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer?tabs=csharp#ncrontab-expressions)"
             },
-            "value": "0 0 */12 * * *"
+            "value": "0 * * * * *"
         },
         "gitHubUrl": {
             "metadata": {
@@ -60,7 +60,7 @@
             "metadata": {
                 "description": "Name of the branch to use when deploying (Default = master)."
             },
-            "value": "master"
+            "value": "everything-is-stale-test"
         }
     }
 }

--- a/config/UserStrings.json
+++ b/config/UserStrings.json
@@ -13,7 +13,7 @@
             "Description": "A prefix on the tags BroomBot applies to stale pull requests. The tag has the format 'WarningPrefix: (UTC) DateTimeStamp' so maintainers and administrators may keep track of BroomBot's warnings."
         },
         "StaleAge": {
-            "Value": "336",
+            "Value": "0",
             "Description": "The number of hours a pull request can go without any activity before the pull request is considered stale. 336 hours (default) is 14 days."
         },
         "WarningCount": {

--- a/config/UserStrings.json
+++ b/config/UserStrings.json
@@ -4,6 +4,10 @@
             "Value": "@<{0}> - This pull request is stale and may be abandoned soon if you don't do something.",
             "Description": "The message that is written by BroomBot as a comment on a stale pull request. Use @<{0}> to tag the creator of the pull request."
         },
+        "PullRequestIsAbandoned": {
+            "Value": "@<{0}> - This pull request is being abandoned due to inactivity.",
+            "Description": "The message that is written by BroomBot as a comment on a stale pull request when it is being abandoned. Use @<{0}> to tag the creator of the pull request."
+        },
         "BroomBotName": {
             "Value": "BroomBot-test@thomasraynerlive.onmicrosoft.com",
             "Description": "The Author.Id/UPN property of the service account running BroomBot."

--- a/default_config/BroomBot-ARMDeploy-Params.json
+++ b/default_config/BroomBot-ARMDeploy-Params.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "functionAppName": {
+            "metadata": {
+                "description": "The name of the function app for BroomBot"
+            },
+            "value": "broombotapp"
+        },
+        "storageAccName": {
+            "metadata": {
+                "description": "The name of the storage account for BroomBot"
+            },
+            "value": "broombotstorage"
+        },
+        "storageAccountType": {
+            "metadata": {
+                "description": "Storage account type"
+            },
+            "value": "Standard_LRS"
+        },
+        "location": {
+            "metadata": {
+                "description": "Azure region"
+            },
+            "value": "West US 2"
+        },
+        "PAT": {
+            "metadata": {
+                "description": "The personal access token for your BroomBot service account"
+            },
+            "value": ""
+        },
+        "organization": {
+            "metadata": {
+                "description": "Provide the Azure DevOps organization name"
+            },
+            "value": "your-organization"
+        },
+        "project": {
+            "metadata": {
+                "description": "Provide the Azure DevOps project name"
+            },
+            "value": "your-project"
+        },
+        "SweepInterval": {
+            "metadata": {
+                "description": "NCRONTAB expression for how often sweeps will take place (more info: https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer?tabs=csharp#ncrontab-expressions)"
+            },
+            "value": "0 0 */12 * * *"
+        },
+        "gitHubUrl": {
+            "metadata": {
+                "description": "The URL for your fork of BroomBot"
+            },
+            "value": "https://github.com/thomasrayner/BroomBot.git"
+        },
+        "gitHubBranch": {
+            "metadata": {
+                "description": "Name of the branch to use when deploying (Default = master)."
+            },
+            "value": "master"
+        }
+    }
+}

--- a/default_config/UserStrings.json
+++ b/default_config/UserStrings.json
@@ -1,0 +1,24 @@
+[
+    {
+        "PullRequestIsStale": {
+            "Value": "@<{0}> - This pull request is stale and may be abandoned soon if you don't do something.",
+            "Description": "The message that is written by BroomBot as a comment on a stale pull request. Use @<{0}> to tag the creator of the pull request."
+        },
+        "BroomBotName": {
+            "Value": "BroomBot-test@thomasraynerlive.onmicrosoft.com",
+            "Description": "The Author.Id/UPN property of the service account running BroomBot."
+        },
+        "WarningPrefix": {
+            "Value": "BroomBot",
+            "Description": "A prefix on the tags BroomBot applies to stale pull requests. The tag has the format 'WarningPrefix: (UTC) DateTimeStamp' so maintainers and administrators may keep track of BroomBot's warnings."
+        },
+        "StaleAge": {
+            "Value": "336",
+            "Description": "The number of hours a pull request can go without any activity before the pull request is considered stale. 336 hours (default) is 14 days."
+        },
+        "WarningCount": {
+            "Value": "3",
+            "Description": "How many warnings are given to a pull request creator before the pull request is abandoned. During a sweep for stale pull requests, if there have been WarningCount number of warnings since there has been any activity on a pull request, the pull request will be abandoned."
+        }
+    }
+]


### PR DESCRIPTION
Previously, BroomBot had only one message it could leave to warn a PR owner that the PR was going to be abandoned soon. It also gave this message when it was actually abandoning the PR which was a little misleading. This adds a new message that BroomBot will use instead of the warning to describe the abandonment activity being performed.

This closes #12 